### PR TITLE
Add pirate English translation

### DIFF
--- a/lang/drophighlighter/en_pt.json
+++ b/lang/drophighlighter/en_pt.json
@@ -1,0 +1,6 @@
+{
+  "key.drophighlighter.toggle": "Toggle th' Drop Highlight, Savvy?",
+  "key.category.drophighlighter.main": "Drop Highlighter",
+  "message.drophighlighter.enabled": "Drop Highlighter: AYE!",
+  "message.drophighlighter.disabled": "Drop Highlighter: NAY!"
+}


### PR DESCRIPTION
## Summary
- Adds `en_pt.json` pirate English translation for the Drop Highlighter mod
- Translates toggle, enabled, and disabled messages into pirate speak (AYE/NAY)

## Test plan
- [ ] Verify the JSON is valid and loads correctly
- [ ] Confirm pirate locale (`en_pt`) is picked up by the mod

🤖 Generated with [Claude Code](https://claude.com/claude-code)